### PR TITLE
Add `disabled` attribute to `copyItem`.

### DIFF
--- a/cheval.js
+++ b/cheval.js
@@ -100,6 +100,7 @@
           var dollyTheSheep = originalCopyItem.cloneNode(true);
           var copyItem = document.createElement('textarea');
           copyItem.style.opacity = 0;
+          copyItem.setAttribute("disabled", true);
           copyItem.style.position = "absolute";
           // If .value is undefined, .textContent will
           // get assigned to the textarea we made.


### PR DESCRIPTION
add copyItem.setAttribute("disabled", true); to prefent flickering on ios devices