### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 Just include the library (~2kB!):
 
-    <script src="https://cdn.jsdelivr.net/cheval/latest/cheval.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/ryanpcmcquen/cheval@latest/cheval.min.js"></script>
 
-https://cdn.jsdelivr.net/cheval/latest/cheval.min.js
+https://cdn.jsdelivr.net/gh/ryanpcmcquen/cheval@latest/cheval.min.js
 
 Provided by:
 
@@ -116,7 +116,7 @@ This project is LibreJS compliant!
 
 If you prefer using specific tags instead of the latest version, you may specify a tag in the `jsDelivr` URL:
 
-https://cdn.jsdelivr.net/cheval/1.1.0/cheval.min.js
+https://cdn.jsdelivr.net/gh/ryanpcmcquen/cheval@1.1.0/cheval.min.js
 
 =====
 


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the links now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/gh/ryanpcmcquen/cheval.

Feel free to ping me if you have any questions regarding this change.