### PR TITLE
Make the update on button texts consistent

### DIFF
--- a/cheval.js
+++ b/cheval.js
@@ -178,9 +178,9 @@
                             }
                         } catch (ignore) {
                             if (allowButtonTextToChange) {
-                              setCopyBtnText(
-                                  afterCopyText.notSupported
-                              );
+                                setCopyBtnText(
+                                    afterCopyText.notSupported
+                                );
                             }
                         }
                         originalCopyItem.focus();

--- a/cheval.js
+++ b/cheval.js
@@ -176,9 +176,11 @@
                                 }
                             }
                         } catch (ignore) {
-                            setCopyBtnText(
-                                afterCopyText.notSupported
-                            );
+                            if (allowButtonTextToChange) {
+                              setCopyBtnText(
+                                  afterCopyText.notSupported
+                              );
+                            }
                         }
                         originalCopyItem.focus();
                         // Restore the user's original position to avoid

--- a/cheval.js
+++ b/cheval.js
@@ -170,6 +170,9 @@
                                         );
                                     }
                                 } else {
+                                    // Hide the onscreen keyboard, which opens
+                                    // on iOS devices, due to the target element
+                                    // being focused on.
                                     document.activeElement.blur();
                                     setCopyBtnText(
                                         afterCopyText.desktop

--- a/cheval.js
+++ b/cheval.js
@@ -170,6 +170,7 @@
                                         );
                                     }
                                 } else {
+                                    document.activeElement.blur();
                                     setCopyBtnText(
                                         afterCopyText.desktop
                                     );


### PR DESCRIPTION
After `execCommand("copy")` is run successfully, the application sets the button text if `allowButtonTextToChange` is set to true:
`if (allowButtonTextToChange) {...} `
This check is missing in the catch block.